### PR TITLE
Remove approved pickups system

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -40,9 +40,6 @@ class OrderController extends BaseController {
         $itemQuantities = Input::get('Quantitys');
         $itemShippings = Input::get("shippingCosts");
         $itemJustifications = Input::get('Justifications');
-        $firstApproved = Input::get("firstApproved");
-        $secondApproved = Input::get("secondApproved");
-        $approvedPickups = array();
         $itemArray = array();
         $grandTotal = 0;
         $order_has_error = false;
@@ -131,17 +128,6 @@ class OrderController extends BaseController {
         foreach($students as $student){
             array_push($enrolledStudents, $student->id);
         }
-        //
-
-        if(($firstApproved != Auth::id()) && ($firstApproved != 0) && (!in_array($firstApproved, $enrolledStudents))){
-            array_push($approvedPickups, $firstApproved);
-        }
-
-        if(($secondApproved != Auth::id())&&($secondApproved != 0)&& (!in_array($secondApproved, $enrolledStudents))){
-            array_push($approvedPickups,$secondApproved);
-        }
-        //Make the array unique
-        array_unique($approvedPickups);
 
         //Ok all passed, we have enough funding, and all items are validated, let's create this order
         $order = new Order;
@@ -170,17 +156,6 @@ class OrderController extends BaseController {
             foreach($itemArray as $item){
                 $item->OrderID = $order->id;
                 $item->save();
-            }
-        }
-
-        //Order created and items saved. Let's do the approved pickups.
-        if(sizeof($approvedPickups) != 0){
-            foreach($approvedPickups as $approvedPickup){
-                $ap = new ApprovedPickup();
-                $ap->PersonID = $approvedPickup;
-                $ap->OrderID = $order->id;
-                $ap->ApproverID = Auth::id();
-                $ap->save();
             }
         }
         //all items saved, order created, redirect to project page with success message

--- a/resources/views/Orders/new.blade.php
+++ b/resources/views/Orders/new.blade.php
@@ -25,42 +25,6 @@
           <div class="col-sm-6">Order Name: {{ Form::text('Description',null,array('class'=>'form-control','tabindex'=>'1','required'))}}</div>
           <div class="col-sm-6">Phone number: {{ Form::text('Phone',null,array('class'=>'form-control','tabindex'=>'2')) }}</div>
       </div>
-      <br />
-          <div class="panel-group" id="approvedPickup">
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent="#approvedPickup" href="#approvedPickups" class="collapsed">
-          Approved Order Pickups
-        </a>
-      </h4>
-    </div>
-    <div id="approvedPickups" class="panel-collapse collapse" style="height: 0px;">
-      <div class="panel-body">
-      The following people are approved to pickup items from this order
-      <ul>
-          <li>{{ Auth::user()->FirstName }} {{ Auth::user()->LastName }}</li>
-          <li>
-              <select name="firstApproved">
-                  <option value="0">Select a team member</option>
-                  @foreach($enrolledStudents as $enrolledStudent)
-                    <option value="{{$enrolledStudent->id}}">{{$enrolledStudent->FirstName}} {{$enrolledStudent->LastName}}</option>
-                  @endforeach
-              </select>
-          </li>
-          <li>
-              <select name="secondApproved">
-                  <option value="0">Select a team member</option>
-                  @foreach($enrolledStudents as $enrolledStudent)
-                      <option value="{{$enrolledStudent->id}}">{{$enrolledStudent->FirstName}} {{$enrolledStudent->LastName}}</option>
-                  @endforeach
-              </select>
-          </li>
-      </ul>
-      </div>
-    </div>
-  </div>
-      </div>
   </div>
 </div>
 


### PR DESCRIPTION
Items are now able to be picked up by any member of the team the item is for (change is retroactive to current items)
Closes #25

We should be able to delete ApprovedPickups.php and its associated reference in Order.php, but I'm a bit scared to do so since the "find all usages" IDE function doesn't work very well for PHP.  Should we drop the table from the database as well?